### PR TITLE
Change the brighness modulation method

### DIFF
--- a/src/breather.v
+++ b/src/breather.v
@@ -32,10 +32,12 @@ module breather (
                 phase_cnt <= phase_cnt + 5'd1;
                 
                 // control brightness, 15 for the brightest
-                if (phase_cnt <= 5'd15) begin
+                if (phase_cnt < 5'd15) begin
                     brightness <= brightness - 4'd1;  // dimer
-                end else begin
+                end else if (phase_cnt > 5'd15 && phase_cnt < 5'd31) begin
                     brightness <= brightness + 4'd1;  // ligher
+                end else begin
+                    brightness <= brightness;
                 end
 
                 // control output clock

--- a/src/breather.v
+++ b/src/breather.v
@@ -45,12 +45,12 @@ module breather (
             end
             
             // determine mask status
-            if (brightness_cnt == 4'hff) begin
+            if (brightness_cnt == 4'hf) begin
                 mask           <= 1;
                 brightness_cnt <= 4'd0;
             end else begin
                 brightness_cnt <= brightness_cnt + 4'd1;
-                if (brightness_cnt >= brightess) mask <= 0;
+                if (brightness_cnt >= brightness) mask <= 0;
             end
         end
         


### PR DESCRIPTION
The mechanism of brightness modulation has been altered to imitate the mixer method. 
That is, dividing the brightness into 16 phases, with 0 being the darkest and 15 being the brightest. The `brightness_cnt` will count until it reaches the `brightness`, at which point the light control signal `mask` will be pulled down.